### PR TITLE
capitalise the first reference to 'Stanley'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ mod database;
                         //***/////                 ,*/(((.
                        ///(//////                 ,*/((((/
                       /////*/////                 *////(((
-/* This is stanley. Stanley was given to me by /u/jimmybilly100. Stanley is an easter egg to be put
+/* This is Stanley. Stanley was given to me by /u/jimmybilly100. Stanley is an easter egg to be put
 * in this program where possible, because he is such a good boy */
 
 #[tokio::main]


### PR DESCRIPTION
Stanley is a name, and in the English language names have to be capitalised.

(This is a joke if you couldn't tell, but this project looks cool so please work on it.)